### PR TITLE
一時保存データの復元強化

### DIFF
--- a/content.js
+++ b/content.js
@@ -28,6 +28,16 @@ setInterval(() => {
       const obj = res[makeStorageKey()];
       if (obj) {
         try {
+          // 🌟 保存したHTMLを丸ごと復元
+          if (obj.hourWorkHtml) {
+            const hourWork = document.querySelector(".hour-work");
+            if (hourWork) {
+              hourWork.outerHTML = obj.hourWorkHtml;
+            }
+            console.log("【復元HTML】", obj.hourWorkHtml);
+          }
+
+          // 入力欄へ保存した値を入れる
           const workInputs = document.querySelectorAll(
             '.timecards_hidden_data input[type="number"]'
           );
@@ -46,6 +56,7 @@ setInterval(() => {
           if (textarea && !textarea.disabled) {
             textarea.value = obj.reason;
           }
+          console.log("【復元完了】", obj);
           tempDataRestored = true;
         } catch (e) {
           console.error("復元エラー:", e);
@@ -82,12 +93,15 @@ setInterval(() => {
       const breakValues = Array.from(breakInputs).map((i) => i.value);
       const textarea = document.getElementById("update_reason");
       const reasonText = textarea ? textarea.value : "";
+      const hourWork = document.querySelector(".hour-work");
+      const hourWorkHtml = hourWork ? hourWork.outerHTML : "";
 
       // 保存するデータオブジェクト
       const data = {
         work: workValues, // 勤務時間
         break: breakValues, // 休憩時間
         reason: reasonText, // 理由テキスト
+        hourWorkHtml: hourWorkHtml, // hour-work 全体
       };
 
       // chrome.storage.local に保存
@@ -98,8 +112,6 @@ setInterval(() => {
       });
     });
 
-    // ページ初回表示時に復元
-    restoreTempData();
   }
 
   // ■ 勤怠実績UI の表示判定
@@ -120,8 +132,6 @@ setInterval(() => {
     return;
   }
 
-  // ■ 編集可能なら保存データを復元
-  restoreTempData();
 
   // 2. 勤怠実績UI の初回描画
   if (!previousVisible) {
@@ -153,6 +163,8 @@ setInterval(() => {
 
     // 初期文字
     textarea.value = "勤務実績";
+    // 初期値入力後に一時保存データを復元
+    restoreTempData();
 
     // ────────────────
     // 2-2. DOMコンテナ


### PR DESCRIPTION
## 概要
- 一時保存時に `.hour-work` 要素の HTML を保存するよう対応
- 復元時に保存した HTML を丸ごと挿入し、値も再設定
- 初期値「勤務実績」入力後に復元処理を実行
- 復元完了時のログを追加

## テスト
- `node --check content.js` を実行し構文エラーがないことを確認

------
https://chatgpt.com/codex/tasks/task_e_6874702d3304832f89cc09b8047432dc