### PR TITLE
Fix restore data with hour work

### DIFF
--- a/content.js
+++ b/content.js
@@ -4,6 +4,7 @@
 let previousVisible = false; // 勤怠実績UIが描画済みか
 let tempSaveInitialized = false; // 一時保存ボタンが追加済みか
 let tempDataRestored = false; // 一時保存データを復元したかどうか
+let restoredReason = ""; // 復元した理由テキスト
 
 // 1. 500msごとに監視
 setInterval(() => {
@@ -33,6 +34,13 @@ setInterval(() => {
             const hourWork = document.querySelector(".hour-work");
             if (hourWork) {
               hourWork.outerHTML = obj.hourWorkHtml;
+              // 復元した要素の入力欄を使えるようにする
+              const newHourWork = document.querySelector(".hour-work");
+              if (newHourWork) {
+                newHourWork.querySelectorAll("input").forEach((inp) => {
+                  inp.disabled = false;
+                });
+              }
             }
             console.log("【復元HTML】", obj.hourWorkHtml);
           }
@@ -52,6 +60,8 @@ setInterval(() => {
             if (breakInputs[i]) breakInputs[i].value = v;
           });
 
+          // 理由テキストは後で上書きするため保持しておく
+          restoredReason = obj.reason || "";
           const textarea = document.getElementById("update_reason");
           if (textarea && !textarea.disabled) {
             textarea.value = obj.reason;
@@ -429,6 +439,10 @@ setInterval(() => {
     // ────────────────
     wrapper.append(editBtn, workTypeWrapper, reasonWrapper, actionGroup);
     textarea.parentElement.appendChild(wrapper);
-    loadAndRender();
+    loadAndRender(() => {
+      if (tempDataRestored && restoredReason) {
+        textarea.value = restoredReason;
+      }
+    });
   }
 }, 500);


### PR DESCRIPTION
## 概要
勤務時間ブロックの HTML を保存して復元する際に、入力欄が無効化されたままになる問題を修正しました。復元処理で入力欄を有効化し、理由テキストを初期化後にも上書きできるようにしています。

## 変更点
- 復元用の理由テキスト `restoredReason` を追加
- 復元処理で hour-work 要素の HTML を差し替え後、入力欄を有効化
- `loadAndRender` 完了後に理由テキストを再設定

## 動作確認
- `node --check content.js` で構文チェック実施


------
https://chatgpt.com/codex/tasks/task_e_6874725b3ec8832f8946c72e9770f243