### PR TITLE
Add automatic reload of updated tabs

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,20 @@
+// == background.js ==
+// 拡張機能をリロードするためのサービスワーカー
+// メッセージを受け取ったらreloadするだけだよ
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg === "reload_extension") {
+    chrome.runtime.reload();
+  }
+});
+
+// 拡張機能が更新された直後に実行されるよ
+// kintaiページを開いているタブがあったら再読み込みするよ
+chrome.runtime.onInstalled.addListener(() => {
+  // 取得したいURLパターンを設定
+  chrome.tabs.query({ url: "https://kintai.jinjer.biz/*" }, (tabs) => {
+    for (const tab of tabs) {
+      chrome.tabs.reload(tab.id);
+    }
+  });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,13 @@
   "version": "1.0",
   "description": "残業・理由ボタンを自動表示・編集可能にする拡張",
   "permissions": ["storage"],
-  "host_permissions": ["https://kintai.jinjer.biz/*"],
+  "host_permissions": [
+    "https://kintai.jinjer.biz/*",
+    "https://raw.githubusercontent.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
   "content_scripts": [
     {
       "matches": ["https://kintai.jinjer.biz/staffs/time_cards"],

--- a/update/mac/update.sh
+++ b/update/mac/update.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Githubから最新バージョンをダウンロードして更新するスクリプト
+# 更新用にGithubのURLを入れるよ
+REPO_URL="https://github.com/ogatetsu-0501/kintai_helper"
+
+# 作業用の一時フォルダを作るよ
+TMP_DIR=$(mktemp -d)
+
+# 最新のソースを取得
+curl -L "$REPO_URL/archive/refs/heads/main.zip" -o "$TMP_DIR/update.zip"
+
+# ZIPを展開するよ
+unzip -q "$TMP_DIR/update.zip" -d "$TMP_DIR"
+REPO_NAME=$(basename "$REPO_URL")
+
+# default_config.json は上書きしたくないから消しておくよ
+rm -f "$TMP_DIR/$REPO_NAME-main/default_config.json"
+
+# 展開したファイルを上書きコピー
+cp -R "$TMP_DIR/$REPO_NAME-main"/* ../../
+
+# お掃除
+rm -rf "$TMP_DIR"
+
+# 更新が終わったらkintaiページを開いて拡張をリロードするよ
+# もし既に開いているタブがあれば再読み込みするよ
+osascript <<'EOF'
+tell application "Google Chrome"
+  set targetUrl to "https://kintai.jinjer.biz/staffs/time_cards?reload_extension=1"
+  set baseUrl to "https://kintai.jinjer.biz/staffs/time_cards"
+  set found to false
+  repeat with w in every window
+    repeat with t in every tab of w
+      if URL of t starts with baseUrl then
+        set found to true
+        set URL of t to targetUrl
+        reload t
+        exit repeat
+      end if
+    end repeat
+    if found then exit repeat
+  end repeat
+  if not found then
+    open location targetUrl
+  end if
+end tell
+EOF
+
+echo "更新が終わりました。ブラウザが自動で再読み込みされます。"

--- a/update/windows/update.bat
+++ b/update/windows/update.bat
@@ -1,0 +1,29 @@
+@echo off
+REM Githubから最新バージョンをダウンロードして更新するバッチ
+REM 更新用にGithubのURLを入れるよ
+set REPO_URL=https://github.com/ogatetsu-0501/kintai_helper
+
+REM 作業用の一時フォルダを作るよ
+set TMP_DIR=%TEMP%\kintai_update
+if exist %TMP_DIR% rd /s /q %TMP_DIR%
+mkdir %TMP_DIR%
+
+REM 最新のソースを取得
+curl -L %REPO_URL%/archive/refs/heads/main.zip -o %TMP_DIR%\update.zip
+
+REM ZIPを展開するよ
+powershell -Command "Expand-Archive -Path '%TMP_DIR%\update.zip' -DestinationPath '%TMP_DIR%'"
+for %%d in (%TMP_DIR%\*) do set UNZIP_DIR=%%d
+
+REM 展開したファイルを上書きコピー
+if exist "%UNZIP_DIR%\default_config.json" del "%UNZIP_DIR%\default_config.json"
+xcopy /E /Y "%UNZIP_DIR%\*" ..\..\
+
+REM お掃除
+rd /s /q %TMP_DIR%
+
+REM 更新が終わったらkintaiページを開いて拡張をリロードするよ
+start "" "https://kintai.jinjer.biz/staffs/time_cards?reload_extension=1"
+
+echo 更新が終わりました。ブラウザが自動で再読み込みされます。
+pause


### PR DESCRIPTION
## Summary
- 更新後に開いているkintaiページを自動リロードする機能を追加
- mac用更新スクリプトで既存タブを再読み込みするAppleScriptを実行

## Testing
- `bash -n update/mac/update.sh`
- `shellcheck update/mac/update.sh`


------
https://chatgpt.com/codex/tasks/task_e_68749dcb4104832f8d93e8951c988458