### PR TITLE
Windows更新スクリプトの案内文を修正

### DIFF
--- a/update/windows/update.bat
+++ b/update/windows/update.bat
@@ -30,15 +30,7 @@ echo %CDATE%> ..\..\last_update.txt
 REM ===== もう使わない一時フォルダを消す =====
 rd /s /q "%TMP_DIR%"
 
-REM ===== Chromeが動いているか確認する =====
-tasklist /FI "IMAGENAME eq chrome.exe" | find /I "chrome.exe" >nul
-if %ERRORLEVEL%==0 (
-    REM ===== 起動中なら新しいタブで拡張機能ページを開く =====
-    start "" chrome "chrome://extensions/"
-) else (
-    REM ===== 起動していなければChromeを起動して開く =====
-    start "" chrome "chrome://extensions/"
-)
-echo 拡張機能ページを開きました。拡張機能を更新してください。
+REM ===== Chromeを自分で開いて更新しようね =====
+echo Google Chromeでchrome://extensions/を開き、拡張機能を更新してください。
 pause
 


### PR DESCRIPTION
## 概要
- update/windows/update.bat の終盤で自動的に `chrome://extensions/` を開く処理を削除
- 代わりに「Google Chromeで `chrome://extensions/` を開き、拡張機能を更新してください」と表示するように変更

## テスト
- `git status --short` で作業ツリーがクリーンであることを確認

------
https://chatgpt.com/codex/tasks/task_e_6875c3561ef8832fb8bff9f338839a35