### PR TITLE
自動スクロール機能追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -91,6 +91,30 @@ fetch(chrome.runtime.getURL("default_config.json"))
     console.error("default_config.jsonを読み込めませんでした");
   });
 
+// ====== スクロール処理 ======
+// ページが開いたときに実行するよ
+window.addEventListener("load", () => {
+  // 表のスクロール領域を探す
+  const box = document.querySelector("div.table-scroll-box");
+  if (!box) return; // 見つからなければ何もしない
+
+  // すべての行を集める
+  const rows = box.querySelectorAll("tbody tr");
+  for (const row of rows) {
+    // 勤務状況が書かれたセルをさがす
+    const statusCell = row.querySelector("td.status span");
+    // セルがあり文字が『勤務予定』なら実行
+    if (statusCell && statusCell.textContent.trim() === "勤務予定") {
+      const prev = row.previousElementSibling;
+      if (prev) {
+        // 前の行が表の一番上にくるようにスクロール
+        box.scrollTop = prev.offsetTop - box.offsetTop;
+      }
+      break; // 最初に見つかったら終わり
+    }
+  }
+});
+
 
 // 1. 500msごとに監視
 setInterval(() => {


### PR DESCRIPTION
## 概要
勤務状況が「勤務予定」となっている行を検出し、その一つ上の行が表の先頭に来るよう自動スクロールする処理を追加しました。

## 変更内容
- `content.js` にページ読み込み時のスクロール処理を実装
  - 表のスクロール領域を取得
  - 「勤務予定」の行を探して前の行の位置へスクロール

## テスト
- `git status --short` で変更がコミット済みであることを確認

------
https://chatgpt.com/codex/tasks/task_e_68785a16e394832f8d2039ee892bc295