### PR TITLE
シフトテンプレ復元時に自動入力が働くよう修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -173,6 +173,11 @@ setInterval(() => {
   if (shiftSel && shiftSel !== shiftSelectElement) {
     // 新しく見つけたら覚えておくよ
     shiftSelectElement = shiftSel;
+    // 値が変わったときは次に備えて保存するよ
+    shiftSel.addEventListener("change", () => {
+      // いま選んでいる値をしまっておく
+      localStorage.setItem("savedShiftTemplate", shiftSel.value);
+    });
     // 前に選んだ値を取り出してみるよ
     const saved = localStorage.getItem("savedShiftTemplate");
     if (saved) {
@@ -183,12 +188,10 @@ setInterval(() => {
       if (has) {
         // あったらその値を選ぶよ
         shiftSel.value = saved;
+        // 元のサイトの自動入力を動かすために「change」を知らせるよ
+        shiftSel.dispatchEvent(new Event("change"));
       }
     }
-    // 選び直したときは保存するよ
-    shiftSel.addEventListener("change", () => {
-      localStorage.setItem("savedShiftTemplate", shiftSel.value);
-    });
   }
 
   // 初期設定がまだ読み込めていなければ何もしないよ


### PR DESCRIPTION
## 概要
- シフトテンプレートを前回の選択で自動復元する際、`change` イベントを発火して元の自動入力処理が動くようにした
- 値変更時にはローカルストレージへ保存する仕組みを維持

## テスト
- `npm test` : `Could not read package.json: Error: ENOENT: no such file or directory, open '/workspace/kintai_helper/package.json'`


------
https://chatgpt.com/codex/tasks/task_e_68929d464788832fb049108a7a3948d9