### PR TITLE
保存済みシフト復元時の自動入力を改善

### DIFF
--- a/content.js
+++ b/content.js
@@ -189,7 +189,8 @@ setInterval(() => {
         // あったらその値を選ぶよ
         shiftSel.value = saved;
         // 元のサイトの自動入力を動かすために「change」を知らせるよ
-        shiftSel.dispatchEvent(new Event("change"));
+        // まわりにも届くように、泡(バブル)が上に上がるよう設定するよ
+        shiftSel.dispatchEvent(new Event("change", { bubbles: true }));
       }
     }
   }
@@ -264,6 +265,8 @@ setInterval(() => {
           if (selNew) {
             selNew.disabled = false;
             selNew.value = obj.shiftValue || "";
+            // 選び直したことを伝えて、元の仕組みを動かすよ
+            selNew.dispatchEvent(new Event("change", { bubbles: true }));
           }
 
           // 理由テキストは後で上書きするため保持しておく


### PR DESCRIPTION
## Summary
- シフト選択を復元する際、changeイベントをバブリングさせて元の自動処理を呼び出すようにしました
- 一時保存データ復元時にもchangeイベントを明示的に発火させるよう調整しました

## Testing
- `npm test` (package.json が無いため失敗)


------
https://chatgpt.com/codex/tasks/task_e_6892a9b9957c832f908bf050d00bfe7c