### PR TITLE
表の位置調整処理を追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -87,6 +87,11 @@ fetch(chrome.runtime.getURL("default_config.json"))
 function watchTableAndScroll() {
   const box = document.querySelector("div.table-scroll-box");
   if (box) {
+    // ★ 表の上を画面のいちばん上に合わせるよ
+    box.scrollIntoView({
+      behavior: "auto",
+      block: "start",
+    });
     const rows = box.querySelectorAll("tbody tr");
     for (const row of rows) {
       const statusCell = row.querySelector("td.status span");


### PR DESCRIPTION
## 概要
- テーブルを探す前にページ上端へスクロールする処理を追加

## テスト
- `npm test` (package.json がないため失敗)

------
https://chatgpt.com/codex/tasks/task_e_689c3e4cfa20832f8e5a6e040b0d6a0c