### PR TITLE
テンプレート自動選択前の保存チェックを追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -239,11 +239,17 @@ setInterval(() => {
       const list = data[key] || [];
       list.forEach((t) => addTemplateOption(t.name));
       const saved = data[`savedShiftTemplate_${user}`];
-      if (saved) {
-        const has = Array.from(shiftSel.options).some(
+      // ★ 保存されたテンプレートが本当にあるかチェックするよ
+      const existsInStorage =
+        saved &&
+        (!saved.startsWith("local_template:") ||
+          list.some((t) => `local_template:${t.name}` === saved));
+      if (existsInStorage) {
+        // ★ 選べるテンプレートが見つかったときだけ自動で選ぶよ
+        const hasOption = Array.from(shiftSel.options).some(
           (o) => o.value === saved
         );
-        if (has) {
+        if (hasOption) {
           shiftSel.value = saved;
           shiftSel.dispatchEvent(new Event("change", { bubbles: true }));
         }


### PR DESCRIPTION
## 概要
- テンプレートを自動選択する前に、保存済みテンプレートが存在するか確認する処理を追加

## テスト
- `node --check content.js`
- `npm test` (package.json がないためエラー)


------
https://chatgpt.com/codex/tasks/task_e_68a7be1e0e38832facbf256b088a666a