### PR TITLE
テンプレート復元時に休憩欄が空になる不具合を修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -220,11 +220,17 @@ setInterval(() => {
       const root = shiftSel.closest(".hour-work");
       if (!root) return;
       // ★ すでに休憩の箱があるか見るよ
-      const exists = root.querySelector(".break-times.time_card_container");
-      if (exists) return;
-      // ★ 休憩を包む外側の箱をつくるよ
-      const outer = document.createElement("div");
-      outer.className = "break-times time_card_container";
+      let outer = root.querySelector(".break-times.time_card_container");
+      // ★ 箱があって中に入力欄があるなら何もしないよ
+      if (outer && outer.querySelector(".break-times-data")) return;
+      // ★ 箱がなければ新しく作るよ
+      if (!outer) {
+        outer = document.createElement("div");
+        outer.className = "break-times time_card_container";
+      } else {
+        // ★ 箱だけあって中身が空なら中身をきれいにするよ
+        outer.innerHTML = "";
+      }
       // ★ 本物の休憩の箱をつくるよ
       const wrap = document.createElement("div");
       wrap.id = "pScroll";


### PR DESCRIPTION
## 概要
- 休憩欄が既に存在しても入力欄が無いと再生成されない問題を修正
- 既存の空の休憩欄にも入力欄を追加するよう変更

## テスト
- `node --check content.js`
- `npm test`（package.json 不在のため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68a7c8f2f288832fab57317e90f1a459