### PR TITLE
テンプレート再読込時に既存項目をクリア

### DIFF
--- a/content.js
+++ b/content.js
@@ -444,6 +444,10 @@ setInterval(() => {
       const key = `timecardTemplates_${user}`;
       chrome.storage.local.get([key, `savedShiftTemplate_${user}`], (data) => {
         const list = data[key] || [];
+        // ★ まず前に入ってる自分のテンプレを全部けすよ
+        Array.from(shiftSel.options).forEach((o) => {
+          if (o.value.startsWith("local_template:")) o.remove();
+        });
         // ★ 保存してあるテンプレをぜんぶ足すよ
         list.forEach((t) => addTemplateOption(t.name));
         const saved = data[`savedShiftTemplate_${user}`];


### PR DESCRIPTION
## 概要
- テンプレートを再読み込みするとき、以前の自作テンプレート項目をいったん削除してから追加するようにしました

## テスト
- `npm test` (package.jsonがないため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68a7d4b2c038832fb46280663a296171