### PR TITLE
プルダウン再表示時のシフト復元再実行

### DIFF
--- a/content.js
+++ b/content.js
@@ -140,9 +140,11 @@ setInterval(() => {
     "shift_template_collection_for_timecard_cf"
   );
   if (shiftSel) {
-    // ★ 新しくシフトのプルダウンを見つけたらイベントを付けるよ
+    // ★ 新しいプルダウンを見つけたら準備をやりなおすよ
     if (shiftSel !== shiftSelectElement) {
       shiftSelectElement = shiftSel;
+      // ★ 消えていたときにリセットした復元フラグをもう一度使うよ
+      shiftTemplateRestored = false;
       shiftSel.addEventListener("change", () => {
         const user = getCurrentUserName();
         chrome.storage.local.set(
@@ -196,6 +198,10 @@ setInterval(() => {
         }
       });
     }
+  } else {
+    // ★ プルダウンがなくなったら次に出たときのために忘れておくよ
+    shiftSelectElement = null;
+    shiftTemplateRestored = false;
   }
 
   if (


### PR DESCRIPTION
## 概要
- シフトプルダウンが消えたり出たりするたびに保存シフトを復元するよう修正
- プルダウンが消えた時に復元フラグをリセットする処理を追加

## テスト
- `npm test`（package.jsonがなく実行失敗）

------
https://chatgpt.com/codex/tasks/task_e_68abc129fd90832f8e2d412bd6f7ed3f