### PR TITLE
シフト復元時にpScrollヘッダーを保持するよう修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -211,7 +211,27 @@ setInterval(() => {
           const html = templates[val.substring(CUSTOM_TEMPLATE_PREFIX.length)];
           const pScroll = document.getElementById("pScroll");
           if (pScroll && html !== undefined) {
-            pScroll.innerHTML = html;
+            // ★ 「テンプレートを選択」と書いてある箱を見つけるよ
+            const keepHeader = pScroll.querySelector(
+              ":scope > div.mb30.tampSelect"
+            );
+            // ★ 新しい表を入れるための箱をつくるよ
+            const tmp = document.createElement("div");
+            tmp.innerHTML = html;
+            // ★ 新しい箱にも同じ場所があるか探すよ
+            const tmpHeader = tmp.querySelector(":scope > div.mb30.tampSelect");
+            if (keepHeader) {
+              if (tmpHeader) {
+                // ★ その場所はもとのをそのまま使うよ
+                tmpHeader.replaceWith(keepHeader);
+              } else {
+                // ★ なかったらいちばん上にのせるよ
+                tmp.prepend(keepHeader);
+              }
+            }
+            // ★ 箱の中身をまるごと入れかえるよ
+            pScroll.innerHTML = "";
+            pScroll.append(...tmp.childNodes);
           }
         }
       });


### PR DESCRIPTION
## 概要
- テンプレート復元時、「テンプレートを選択」ブロックをクラス指定で保持するようにしました

## テスト
- `node --check content.js`
- `npm test` (package.json 不足のため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68abc6f40c3c832fa54220c5b12060d8