### PR TITLE
テンプレート登録時に入力値を保存するよう修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -124,6 +124,19 @@ function setupTemplateRegisterButton() {
     const clone = pScroll.cloneNode(true);
     const header = clone.querySelector(":scope > div.mb30.tampSelect");
     if (header) header.remove();
+    // ★ 入力欄と選ぶところの今の状態をメモするよ
+    clone.querySelectorAll("input, select").forEach((el) => {
+      if (el.tagName === "INPUT") {
+        // ★ 入力欄の中身をそのまま覚えておくよ
+        el.setAttribute("value", el.value);
+      } else if (el.tagName === "SELECT") {
+        // ★ 今選ばれているところにしるしを付けるよ
+        el.querySelectorAll("option:checked").forEach((opt) => {
+          opt.setAttribute("selected", "selected");
+        });
+      }
+    });
+    // ★ コピーした表をしまっておくよ
     templates[name] = clone.innerHTML;
     localStorage.setItem("myShiftTemplates", JSON.stringify(templates));
     // ★ 新しいテンプレートをプルダウンにも足すよ


### PR DESCRIPTION
## 概要
- テンプレート登録時に input と select の現在の値を保持する
- コードに子どもにもわかる説明コメントを追加

## テスト
- `npm test` (package.json がなく失敗)

------
https://chatgpt.com/codex/tasks/task_e_68abd0589164832f91167e85d47c290f