### PR TITLE
ボタンと日付表示の縦位置を揃える

### DIFF
--- a/content.js
+++ b/content.js
@@ -234,6 +234,8 @@ function addShiftTemplateSaveButton(sel) {
   });
   const jdate = document.querySelector("div.floatLeft.jdate"); // ★ 日付の場所を見つけるよ
   if (jdate) {
+    jdate.style.display = "inline-block"; // ★ 横に並べても変にならないようにするよ
+    jdate.style.verticalAlign = "middle"; // ★ ボタンと真ん中を合わせるよ
     jdate.insertAdjacentElement("afterend", btn); // ★ 日付の下にボタンを置くよ
   } else {
     sel.parentElement.appendChild(btn); // ★ 見つからなければ元の場所に置くよ


### PR DESCRIPTION
## 概要
- 日付テキストと「テンプレ保存」ボタンの縦位置を中央にそろえました

## テスト
- `npm test`（package.json が無いため実行不可）

------
https://chatgpt.com/codex/tasks/task_e_68ad1de0afe8832fa358f9597be7e8e5