### PR TITLE
日付表示の高さをボタンに合わせる

### DIFF
--- a/content.js
+++ b/content.js
@@ -237,6 +237,9 @@ function addShiftTemplateSaveButton(sel) {
     jdate.style.display = "inline-block"; // ★ 横に並べても変にならないようにするよ
     jdate.style.verticalAlign = "middle"; // ★ ボタンと真ん中を合わせるよ
     jdate.insertAdjacentElement("afterend", btn); // ★ 日付の下にボタンを置くよ
+    const btnHeight = btn.offsetHeight; // ★ ボタンの背の高さを調べるよ
+    jdate.style.lineHeight = `${btnHeight}px`; // ★ 日付の文字も同じ高さにそろえるよ
+    jdate.style.height = `${btnHeight}px`; // ★ 日付の箱も同じ高さにするよ
   } else {
     sel.parentElement.appendChild(btn); // ★ 見つからなければ元の場所に置くよ
   }


### PR DESCRIPTION
## 概要
- ボタンの高さを測って日付テキストの表示をそろえる

## テスト
- `node --check content.js`
- `npm test` (package.jsonがなく失敗するがテストは見当たらない)

------
https://chatgpt.com/codex/tasks/task_e_68ad2164ab2c832fa7666dc82b692f17