### PR TITLE
デフォルトテンプレ選択時の無限更新を防止

### DIFF
--- a/content.js
+++ b/content.js
@@ -353,10 +353,13 @@ setInterval(() => {
                 has = true; // ★ 追加したからあることにするよ
               }
               if (has) {
-                shiftSel.value = saved;
-                shiftSel.dispatchEvent(
-                  new Event("change", { bubbles: true })
-                );
+                if (shiftSel.value !== saved) {
+                  // ★ いまのえらびと違うときだけ動かすよ
+                  shiftSel.value = saved; // ★ 前にえらんだものを入れるよ
+                  shiftSel.dispatchEvent(
+                    new Event("change", { bubbles: true })
+                  ); // ★ 変わったよって知らせるよ
+                }
               }
             }
           });


### PR DESCRIPTION
## 概要
- デフォルトテンプレート選択時に `change` イベントが無限発火して入力値が更新され続ける問題を修正
  - 保存されている値と現在の選択が同じ場合は `change` を発火しないように条件を追加

## テスト
- `npm test` (package.json がないためスクリプトなし)


------
https://chatgpt.com/codex/tasks/task_e_68ad233171c0832f924a6b4be25e34b5