### PR TITLE
ラジオボタンのラベル余白を調整

### DIFF
--- a/content.js
+++ b/content.js
@@ -96,6 +96,17 @@ function fixRadioLabelOverlap() {
     wrap.style.height = "auto";
     wrap.style.display = "flex";
     wrap.style.alignItems = "center";
+
+    // ★ ボタンの右にちょっとだけすきまを作るよ
+    wrap.querySelectorAll('input[type="radio"]').forEach((btn) => {
+      btn.style.marginRight = "4px";
+    });
+
+    // ★ 文字がボタンのすぐ右から始まるようにするよ
+    wrap.querySelectorAll("label").forEach((lab) => {
+      lab.style.marginLeft = "0";
+      lab.style.marginRight = "10px";
+    });
   });
 }
 


### PR DESCRIPTION
## 概要
- ラジオボタンとラベルの余白を調整し、文字がボタンのすぐ右から始まるようにしました

## テスト
- `node --check content.js`
- `npm test`（package.jsonが存在しないため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68ae5cd235ec832f9295cf65279f4fa2