### PR TITLE
ラジオボタン選択時の枠色を水色に変更

### DIFF
--- a/content.js
+++ b/content.js
@@ -1199,7 +1199,12 @@ setInterval(() => {
       border-radius: 50%;
       box-sizing: border-box;
     }
-
+    
+    /* 選ばれたときは枠を水色にするよ */
+    .type_absent .radioCheckWrapper input[type="radio"]:checked + label::before,
+    .type_absent .radioCheckWrapper input[type="checkbox"]:checked + label::before {
+      border: 1px solid #6bd5e5;         /* 枠を水色にするよ */
+    }
 
     /* キーボード操作のフォーカス枠（元にあるならそちらが勝つよ） */
     .type_absent .radioCheckWrapper input[type="radio"]:focus + label::before {
@@ -1299,7 +1304,13 @@ setInterval(() => {
       /* 既存の padding-left:42px はサイトのCSSに任せるよ（そのままでOK） */
     }
 
-    /* C) 中央のチェックマークだけを描くよ（参考に頂いた方式そのまま） */
+    /* C) 選ばれたときは枠を水色にするよ */
+    .type_absent .radioCheckWrapper input[type="radio"]:checked + label::before,
+    .type_absent .radioCheckWrapper input[type="checkbox"]:checked + label::before {
+      border: 1px solid #6bd5e5;      /* 枠を水色にするよ */
+    }
+
+    /* D) 中央のチェックマークだけを描くよ（参考に頂いた方式そのまま） */
     .type_absent .radioCheckWrapper input[type="radio"]:checked + label::after,
     .type_absent .radioCheckWrapper input[type="checkbox"]:checked + label::after{
       content: "";                 /* 疑似要素を出すよ */
@@ -1319,7 +1330,7 @@ setInterval(() => {
       z-index: 1;                  /* 一番前に出すよ */
     }
 
-    /* D) 古い「●ドット」が残っていても消すよ */
+    /* E) 古い「●ドット」が残っていても消すよ */
     .type_absent .radioCheckWrapper input[type="radio"]:checked + label::after{
       background: none !important;
       border-right: none !important;


### PR DESCRIPTION
## Summary
- ラジオ/チェック選択時に枠を水色 (#6bd5e5) で表示
- 最小追記版のスタイルにも同じ変更を適用

## Testing
- `node --check content.js`
- `npm test` (package.json 不在のため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68ae78b06d28832f9284ca5a24ea547f