### PR TITLE
テンプレート削除モーダルのボタン配置を保存モーダルに合わせる

### DIFF
--- a/content.js
+++ b/content.js
@@ -462,11 +462,10 @@ function addShiftTemplateSaveButton(sel) {
 
       // ★ ボタンを横にならべる箱だよ
       const btnWrap = document.createElement("div");
-      btnWrap.style.marginTop = "10px";
-      btnWrap.style.display = "flex";
-      btnWrap.style.justifyContent = "space-between"; // ★ 左右のはしに置くよ
-      btnWrap.style.gap = "10px";
-      btnWrap.style.width = "100%"; // ★ 箱いっぱいの横幅にするよ
+      btnWrap.style.marginTop = "10px"; // ★ 上にすき間をあけるよ
+      btnWrap.style.display = "flex"; // ★ 横にならべるよ
+      btnWrap.style.justifyContent = "center"; // ★ 真ん中にそろえるよ
+      btnWrap.style.gap = "10px"; // ★ ボタンのあいだにすき間をあけるよ
 
       const okBtn = document.createElement("button"); // ★ 消すボタンだよ
       okBtn.textContent = "削除";


### PR DESCRIPTION
## 概要
- テンプレート削除モーダルの削除・キャンセルボタンを中央寄せに変更し、テンプレート保存モーダルと同じ配置に統一

## テスト
- `node --check content.js`


------
https://chatgpt.com/codex/tasks/task_e_68aeb6b88f68832f8118ad319870d5ed