### PR TITLE
テンプレート削除モーダルのチェック枠の色と位置の調整

### DIFF
--- a/content.js
+++ b/content.js
@@ -424,20 +424,20 @@ function addShiftTemplateSaveButton(sel) {
             box-sizing: border-box; /* ★ はみ出さないようにするよ */
           }
           .template-delete-item input[type="checkbox"]:checked + span::before {
-            border: 1px solid #65d3e4; /* ★ えらんだら青いふちだよ */
+            border: 1px solid #6bd5e5; /* ★ えらんだら青いふちだよ */
           }
           .template-delete-item input[type="checkbox"]:checked + span::after {
             content: ""; /* ★ チェックの形を描くよ */
-            position: absolute; /* ★ 位置を決めるよ */
+            position: absolute; /* ★ どこに出すか決めるよ */
             top: 50%; /* ★ たてのまんなかだよ */
-            left: 8px; /* ★ 丸の内側に置くよ */
-            width: 14px; /* ★ チェックの横幅だよ */
-            height: 8px; /* ★ チェックの高さだよ */
-            margin-top: -6px; /* ★ まんなかに見えるようにするよ */
-            border-left: 2px solid #65d3e4; /* ★ 左の線だよ */
-            border-bottom: 2px solid #65d3e4; /* ★ 下の線だよ */
-            transform: rotate(-45deg); /* ★ 傾けてチェックの形にするよ */
-            box-sizing: border-box; /* ★ にじみを防ぐよ */
+            left: 4px; /* ★ 丸のまんなかに合わせるよ */
+            width: 10px; /* ★ チェックの横幅だよ */
+            height: 6px; /* ★ チェックの高さだよ */
+            margin-top: -3px; /* ★ 上下のまんなかに見せるよ */
+            border-left: 2px solid #6bd5e5; /* ★ 左の線だよ */
+            border-bottom: 2px solid #6bd5e5; /* ★ 下の線だよ */
+            transform: rotate(-45deg); /* ★ 斜めにしてチェックを作るよ */
+            box-sizing: border-box; /* ★ はみ出さないようにするよ */
             display: block; /* ★ 形をしっかり見せるよ */
           }
         `;


### PR DESCRIPTION
## 概要
- チェックボックスの枠を既定の水色に統一
- チェックマークが中央に来るよう位置と大きさを調整

## テスト
- `npm test` で `package.json` がなく実行不可を確認

------
https://chatgpt.com/codex/tasks/task_e_68aebba9ecc0832f93f3aca90a8432e7